### PR TITLE
Run pre-commit hooks using pre-commit tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ defaults:
       - run: go get -u $COMMON_GO_PACKAGES
       - run: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
       - run: dep ensure -dry-run
-      - run: sudo apt-get python-pip
+      - run: sudo apt-get install python-pip
       - run: sudo pip install pre-commit
       - run: pre-commit install
       - run: pre-commit run -a

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ defaults:
       - run: go get -u $COMMON_GO_PACKAGES
       - run: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
       - run: dep ensure -dry-run
-      - run: sudo apt-get install python pip
+      - run: sudo apt-get python-pip
       - run: sudo pip install pre-commit
       - run: pre-commit install
       - run: pre-commit run -a

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,9 @@ defaults:
       - run: go get -u $COMMON_GO_PACKAGES
       - run: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
       - run: dep ensure -dry-run
-      - run: make init
-      - run: make lint
+      - run: sudo pip install pre-commit
+      - run: pre-commit install
+      - run: pre-commit run -a
       - run:
           name: Set up Code Climate test-reporter
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ defaults:
       - run: sudo apt-get install python-pip
       - run: sudo pip install pre-commit
       - run: pre-commit install
-      - run: pre-commit run -a
+      - run: SKIP=go-unit-tests pre-commit run -a
       - run:
           name: Set up Code Climate test-reporter
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ defaults:
       - run: go get -u $COMMON_GO_PACKAGES
       - run: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
       - run: dep ensure -dry-run
+      - run: sudo apt-get install python pip
       - run: sudo pip install pre-commit
       - run: pre-commit install
       - run: pre-commit run -a

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+- repo: https://github.com/golangci/golangci-lint
+  rev: v1.12.5
+  hooks:
+  - id: golangci-lint
+    name: golangci-lint
+    description: Fast linters runner for Go.
+    entry: golangci-lint run
+    types: [go]
+    language: golang
+    pass_filenames: false
+
+- repo: git://github.com/dnephin/pre-commit-golang
+  sha: HEAD
+  hooks:
+    - id: go-unit-tests

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ test: lint
 	go test ./...
 
 lint:
-	./bin/golangci-lint run ./...
+    pre-commit run -a --verbose golangci-lint
 
 init:
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s $(GOLANGCI_VERSION)
+	pre-commit install
 
 RELEASE_CMD=curl -sL https://git.io/goreleaser | bash -s -- --rm-dist
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test: lint
 	go test ./...
 
 lint:
-    pre-commit run -a --verbose golangci-lint
+	pre-commit run -a --verbose golangci-lint
 
 init:
 	pre-commit install


### PR DESCRIPTION
pre-commit.com is Yelp's pre-commit tool.  The config setup is a little verbose but it does three things that are useful:

1) It is really easy to install.
2) It allows us to pin to a version of golangci-lint.
3) It runs only on the changes that will be committed (by stashing anything not staged when running the commits) .
