### PR TITLE
Add commands to manage configs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
+	"os"
 
 	ldapi "github.com/launchdarkly/api-client-go"
 )
@@ -17,7 +19,7 @@ var Auth context.Context
 // Client is the api client
 var Client *ldapi.APIClient
 
-const defaultServer = "https://app.launchdarkly.com/api/v2"
+const defaultServer = "https://app.launchdarkly.com"
 
 // CurrentToken is the api token
 var CurrentToken string
@@ -86,13 +88,20 @@ func init() {
 
 // SetServer sets the server url to use
 func SetServer(newServer string) {
+	url, err := url.Parse(newServer)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Unable to parser server: %s", err)
+		return
+	}
 	CurrentServer = newServer
+	url.Path = "/api/v2"
+	url.RawPath = ""
 	Client = ldapi.NewAPIClient(&ldapi.Configuration{
-		BasePath: newServer,
+		BasePath: url.String(),
 		HTTPClient: &http.Client{
 			Transport: &loggingTransport{},
 		},
-		UserAgent: "ldc/0.0.1/go",
+		UserAgent: UserAgent,
 	})
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,11 +2,92 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 
-	ishell "gopkg.in/abiosoft/ishell.v2"
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/viper"
+
+	"gopkg.in/abiosoft/ishell.v2"
 
 	"github.com/launchdarkly/ldc/api"
 )
+
+type config struct {
+	// APIToken is the authorization token
+	APIToken string // `json:"apiToken"`
+	// Server is the api url (.../v2)
+	Server string // `json:"server,omitempty"`
+	// DefaultProject is the initial project to use
+	DefaultProject string // `json:"defaultProject"`
+	// DefaultEnvironment is the initial environment to use
+	DefaultEnvironment string // `json:"defaultEnvironment"`
+}
+
+var configFile map[string]config
+var configViper *viper.Viper
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	configViper = viper.New()
+	if cfgFile != "" {
+		// Use config file from the flag.
+		configViper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := homedir.Dir()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		configViper.AddConfigPath(home)
+		configViper.AddConfigPath(filepath.Join(home, ".config"))
+		configViper.AddConfigPath(".")
+		configViper.SetConfigName("ldc")
+	}
+
+	if err := configViper.ReadInConfig(); err == nil {
+		if err := configViper.Unmarshal(&configFile); err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to parse config file: %s", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func addConfigCommands(shell *ishell.Shell) {
+	root := &ishell.Cmd{
+		Name: "configs",
+		Help: "Update configurations",
+	}
+	root.AddCmd(&ishell.Cmd{
+		Name:      "set",
+		Help:      "Change configuration",
+		Completer: configCompleter,
+		Func:      selectConfig,
+	})
+	root.AddCmd(&ishell.Cmd{
+		Name: "add",
+		Help: "add config <config name> <api token> <project> <environment> [server url]",
+		Func: addConfig,
+	})
+	root.AddCmd(&ishell.Cmd{
+		Name:      "edit",
+		Aliases:   []string{"update"},
+		Help:      "update config: <config name> <api token> <project> <environment> [server url]",
+		Completer: configCompleter,
+		Func:      updateConfig,
+	})
+	root.AddCmd(&ishell.Cmd{
+		Name:      "rm",
+		Aliases:   []string{"remove", "delete", "del"},
+		Help:      "remove config: <config name>",
+		Completer: configCompleter,
+		Func:      removeConfig,
+	})
+	shell.AddCmd(root)
+}
 
 func listConfigs() (map[string]config, error) {
 	return configFile, nil
@@ -81,4 +162,154 @@ func setConfig(name string, config config) {
 	api.CurrentEnvironment = config.DefaultEnvironment
 	api.SetToken(config.APIToken)
 	api.SetServer(config.Server)
+}
+
+func updateConfig(c *ishell.Context) {
+	if len(c.Args) > 1 && len(c.Args) < 4 {
+		c.Err(tooFewArgs)
+		return
+	}
+
+	if len(c.Args) > 5 {
+		c.Err(tooManyArgs)
+		return
+	}
+
+	name, config := getConfigArg(c)
+
+	if config == nil {
+		c.Println("Config not found. Settings unchanged.")
+		return
+	}
+
+	newConfig := config
+
+	if len(c.Args) <= 1 {
+		c.Printf(`API Token (default "%s"): `, config.APIToken)
+		val, err := c.ReadLineErr()
+		if err != nil {
+			c.Err(err)
+			return
+		}
+		newConfig.APIToken = ifNotBlank(val, config.APIToken)
+
+		c.Printf(`Default Project (default "%s"): `, config.DefaultProject)
+		val, err = c.ReadLineErr()
+		if err != nil {
+			c.Err(err)
+			return
+		}
+		newConfig.DefaultProject = ifNotBlank(val, config.DefaultProject)
+
+		c.Printf(`Default Environment (default "%s"): `, config.DefaultEnvironment)
+		val, err = c.ReadLineErr()
+		if err != nil {
+			c.Err(err)
+			return
+		}
+		newConfig.DefaultEnvironment = ifNotBlank(val, config.DefaultEnvironment)
+
+		c.Printf(`Server (leave blank for "%s" or "-" for default): `, config.Server)
+		val, err = c.ReadLineErr()
+		if err != nil {
+			c.Err(err)
+			return
+		}
+		if val == "-" {
+			val = ""
+		}
+		newConfig.Server = ifNotBlank(val, config.Server)
+	} else {
+		newConfig.APIToken = c.Args[1]
+		newConfig.DefaultProject = c.Args[2]
+		newConfig.DefaultEnvironment = c.Args[3]
+		if len(c.Args) > 4 {
+			newConfig.Server = c.Args[4]
+		} else {
+			newConfig.Server = ""
+		}
+	}
+
+	configViper.Set(name, newConfig)
+	configViper.WriteConfig()
+	c.Println("configuration updated")
+}
+
+func removeConfig(c *ishell.Context) {
+	name, config := getConfigArg(c)
+	if config == nil {
+		c.Err(errors.New("config not found"))
+		return
+	}
+	configViper.Set(name, nil)
+	configViper.WriteConfig()
+	c.Println("configuration removed")
+}
+
+func addConfig(c *ishell.Context) {
+	if len(c.Args) > 1 && len(c.Args) < 4 {
+		c.Err(tooFewArgs)
+		return
+	}
+
+	if len(c.Args) > 5 {
+		c.Err(tooManyArgs)
+		return
+	}
+
+	name, config := getConfigArg(c)
+
+	if config == nil {
+		c.Println("Config not found. Settings unchanged.")
+		return
+	}
+
+	newConfig := config
+
+	if len(c.Args) <= 1 {
+		c.Printf("API Token: ")
+		val, err := c.ReadLineErr()
+		if err != nil {
+			c.Err(err)
+			return
+		}
+		newConfig.APIToken = val
+
+		c.Printf(`Default Project (default "default"): `)
+		val, err = c.ReadLineErr()
+		if err != nil {
+			c.Err(err)
+			return
+		}
+		newConfig.DefaultProject = ifNotBlank(val, "default")
+
+		c.Printf(`Default Environment (default "production"): `)
+		val, err = c.ReadLineErr()
+		if err != nil {
+			c.Err(err)
+			return
+		}
+		newConfig.DefaultEnvironment = ifNotBlank(val, "production")
+
+		c.Printf("Server (leave blank for default): ")
+		val, err = c.ReadLineErr()
+		if err != nil {
+			c.Err(err)
+			return
+		}
+		newConfig.Server = ifNotBlank(val, "")
+	} else {
+		newConfig.APIToken = c.Args[1]
+		newConfig.DefaultProject = c.Args[2]
+		newConfig.DefaultEnvironment = c.Args[3]
+		if len(c.Args) > 4 {
+			newConfig.Server = c.Args[4]
+		} else {
+			newConfig.Server = ""
+		}
+	}
+
+	configViper.Set(name, newConfig)
+	configViper.WriteConfig()
+	c.Println("configuration added")
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -22,8 +22,9 @@ const (
 	cJSON        = "json"
 )
 
-var tooManyArgs = errors.New("too many arguments")
-var tooFewArgs = errors.New("too many arguments")
+var errTooManyArgs = errors.New("too many arguments")
+var errTooFewArgs = errors.New("too few arguments")
+var errNotFound = errors.New("not found")
 
 func confirmDelete(c *ishell.Context, name string, expectedValue string) bool {
 	if !isInteractive(c) {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -20,6 +21,9 @@ const (
 	cEDITOR      = "editor"
 	cJSON        = "json"
 )
+
+var tooManyArgs = errors.New("too many arguments")
+var tooFewArgs = errors.New("too many arguments")
 
 func confirmDelete(c *ishell.Context, name string, expectedValue string) bool {
 	if !isInteractive(c) {
@@ -226,4 +230,11 @@ func printJSON(c *ishell.Context, data interface{}) {
 	}
 
 	c.Print(string(bytes) + "\n")
+}
+
+func ifNotBlank(s string, defaultValue string) string {
+	if strings.TrimSpace(s) == "" {
+		return defaultValue
+	}
+	return s
 }


### PR DESCRIPTION
Remove is broken for some reason.  Might just not be supported by viper.  Thought I'd merge it anyway and figure it out later.

This also changes the code so that the server value is just the base url without api/v2 suffix.