### PR TITLE
Don't report error if no config is found

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.13.2
+  rev: v1.16.0
   hooks:
   - id: golangci-lint
     name: golangci-lint
@@ -11,6 +11,6 @@ repos:
     pass_filenames: false
 
 - repo: git://github.com/dnephin/pre-commit-golang
-  sha: HEAD
+  rev: v0.3.3
   hooks:
     - id: go-unit-tests

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -59,7 +59,7 @@ func reloadConfigFile() {
 			fmt.Fprintf(os.Stderr, "Unable to parse config file: %s", err)
 			os.Exit(1)
 		}
-	} else {
+	} else if _, notFound := err.(viper.ConfigFileNotFoundError); !notFound {
 		fmt.Fprintf(os.Stderr, "Error loading config file: %s\n", err)
 	}
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -53,14 +53,20 @@ func initConfig() {
 }
 
 func reloadConfigFile() {
-	configFile = nil
-	if err := configViper.ReadInConfig(); err == nil {
-		if err := configViper.Unmarshal(&configFile); err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to parse config file: %s", err)
-			os.Exit(1)
+	if err := configViper.ReadInConfig(); err != nil {
+		configFileExpected := configFileName != ""
+		_, errIsNotFound := err.(viper.ConfigFileNotFoundError)
+		if !configFileExpected && errIsNotFound {
+			return
 		}
-	} else if _, notFound := err.(viper.ConfigFileNotFoundError); !notFound {
 		fmt.Fprintf(os.Stderr, "Error loading config file: %s\n", err)
+		os.Exit(1)
+	}
+
+	configFile = nil
+	if err := configViper.Unmarshal(&configFile); err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to parse config file: %s", err)
+		os.Exit(1)
 	}
 }
 

--- a/cmd/goal.go
+++ b/cmd/goal.go
@@ -163,9 +163,6 @@ func chooseGoal(c *ishell.Context, config *string, project string, env string) (
 	for _, g := range goals {
 		options = append(options, g.Name)
 	}
-	if err != nil {
-		return nil, err
-	}
 	choice := c.MultiChoice(options, "Choose a goal: ")
 	if choice < 0 {
 		return nil, err


### PR DESCRIPTION
Only fail with an error if config is explicitly expected but still not found.

Also update pre-commit hooks and remove some unused code found by linter.